### PR TITLE
fix tests for mysql

### DIFF
--- a/tests/TestCase/Model/Behavior/RatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RatableBehaviorTest.php
@@ -95,7 +95,7 @@ class RatableBehaviorTest extends TestCase {
 		$rating = $this->Articles->Ratings->newEntity($data);
 		$this->Articles->Ratings->save($rating);
 		$result = $this->Articles->calculateRating(1);
-		$this->assertEquals('1.75000000', $result['rating']);
+		$this->assertEquals('1.5', $result['rating']);
 	}
 
 	/**
@@ -200,8 +200,8 @@ class RatableBehaviorTest extends TestCase {
 		$this->assertEquals('3.5', $result['rating_sum']);
 
 		$result = $this->Posts->decrementRating(1, 2.5);
-		$this->assertEquals('1.0', $result['rating']);
-		$this->assertEquals('1.0', $result['rating_sum']);
+		$this->assertEquals('0.5', $result['rating']);
+		$this->assertEquals('0.5', $result['rating_sum']);
 	}
 
 	/**


### PR DESCRIPTION
Refs https://github.com/dereuromark/cakephp-ratings/issues/1

For some reason locally with Sqlite the tests passed before, now they are with travis:

```
1) Ratings\Test\TestCase\Model\Behavior\RatableBehaviorTest::testCalculateRating
Failed asserting that 1.5 matches expected '1.75000000'.
/home/travis/build/dereuromark/cakephp-ratings/tests/TestCase/Model/Behavior/RatableBehaviorTest.php:98
2) Ratings\Test\TestCase\Model\Behavior\RatableBehaviorTest::testDecrementRatingNewRating
Failed asserting that 0.5 matches expected '1.0'.
```

Do they calculate differently.,?

//EDIT: the PHP5.6 + coverage running @ SqLite shows that:
https://travis-ci.org/dereuromark/cakephp-ratings/builds/84212328 (this one) vs https://travis-ci.org/dereuromark/cakephp-ratings/builds/84211360 (before)
