### PR TITLE
Fix fixture column length type for PHP 8.5 compatibility

### DIFF
--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -30,7 +30,7 @@ class ArticlesFixture extends TestFixture {
 		'id' => ['type' => 'integer'],
 		'user_id' => ['type' => 'integer', 'null' => false, 'length' => 10],
 		'title' => ['type' => 'string', 'null' => false],
-		'rating' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => '10,2'],
+		'rating' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => 10, 'precision' => 2],
 		'rating_1' => ['type' => 'integer', 'null' => false, 'default' => 0, 'length' => 5],
 		'rating_2' => ['type' => 'integer', 'null' => false, 'default' => 0, 'length' => 5],
 		'rating_3' => ['type' => 'integer', 'null' => false, 'default' => 0, 'length' => 5],

--- a/tests/Fixture/PostsFixture.php
+++ b/tests/Fixture/PostsFixture.php
@@ -29,9 +29,9 @@ class PostsFixture extends TestFixture {
 	public array $fields = [
 		'id' => ['type' => 'integer'],
 		'title' => ['type' => 'string', 'null' => false],
-		'rating' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => '10,2'],
-		'rating_sum' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => '10,2'],
-		'rating_count' => ['type' => 'integer', 'null' => false, 'default' => '0', 'length' => '10'],
+		'rating' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => 10, 'precision' => 2],
+		'rating_sum' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => 10, 'precision' => 2],
+		'rating_count' => ['type' => 'integer', 'null' => false, 'default' => '0', 'length' => 10],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']]],
 	];
 

--- a/tests/Fixture/RatingsFixture.php
+++ b/tests/Fixture/RatingsFixture.php
@@ -30,7 +30,7 @@ class RatingsFixture extends TestFixture {
 		'user_id' => ['type' => 'integer', 'null' => true, 'default' => null],
 		'foreign_key' => ['type' => 'integer', 'null' => false, 'default' => null],
 		'model' => ['type' => 'string', 'null' => false, 'default' => null],
-		'value' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => '8,4'],
+		'value' => ['type' => 'float', 'null' => false, 'default' => '0', 'length' => 8, 'precision' => 4],
 		'created' => ['type' => 'datetime', 'null' => false, 'default' => null],
 		'modified' => ['type' => 'datetime', 'null' => false, 'default' => null],
 		'_constraints' => ['primary' => ['type' => 'primary', 'columns' => ['id']], 'UNIQUE_RATING' => ['type' => 'unique', 'columns' => ['user_id', 'foreign_key', 'model']]],


### PR DESCRIPTION
## Summary

- Fix fixture schema definitions to use integer `length` with separate `precision` instead of string format `'10,2'`

CakePHP's `Column::__construct()` now strictly requires the `length` parameter to be `?int`, not a string. The old format `'length' => '10,2'` for decimal columns needs to be split into `'length' => 10, 'precision' => 2`.

## Test plan

- [ ] CI should pass on PHP 8.5