### PR TITLE
Enforce self-vote guard on saveRating and fix user-id resolution

### DIFF
--- a/src/Controller/Component/RatingComponent.php
+++ b/src/Controller/Component/RatingComponent.php
@@ -15,6 +15,7 @@ use Cake\Controller\Component;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Cake\ORM\Exception\MissingTableClassException;
+use LogicException;
 use ReflectionClass;
 
 /**
@@ -98,22 +99,42 @@ class RatingComponent extends Component {
 			return;
 		}
 
-		$userId = $this->getConfig('userId') ?: null;
-		if (!$userId && $this->Controller->getRequest()->getAttribute('identity')) {
-			$identity = $this->Controller->getRequest()->getAttribute('identity');
-			$userId = $identity->get($this->getConfig('userIdField'));
-		} elseif (!$userId && $this->Controller->components()->has('AuthUser')) {
-			$userId = $this->Controller->AuthUser->id();
-		} if (!$userId && $this->Controller->components()->has('Auth')) {
-			$userId = $this->Controller->Auth->user($this->getConfig('userIdField'));
-		} else {
-			//$userId = $this->Controller->getRequest()->getSession()->read('Auth.User.id');
-		}
+		$userId = $this->resolveUserId();
 
 		$rate = $this->rate($params['rate'], (float)$params['rating'], $userId, $params['redirect']);
 		if ($rate) {
 			$event->setResult($rate);
 		}
+	}
+
+	/**
+	 * Resolves the active user id from configured override, the request identity
+	 * (Authentication plugin), or a legacy AuthUser/Auth component if attached.
+	 *
+	 * Returns null when no user can be resolved - callers must handle this.
+	 *
+	 * @return string|int|null
+	 */
+	protected function resolveUserId(): string|int|null {
+		$userId = $this->getConfig('userId');
+		if ($userId) {
+			return $userId;
+		}
+
+		$identity = $this->Controller->getRequest()->getAttribute('identity');
+		if ($identity) {
+			return $identity->get($this->getConfig('userIdField'));
+		}
+
+		if ($this->Controller->components()->has('AuthUser')) {
+			return $this->Controller->AuthUser->id();
+		}
+
+		if ($this->Controller->components()->has('Auth')) {
+			return $this->Controller->Auth->user($this->getConfig('userIdField'));
+		}
+
+		return null;
 	}
 
 	/**
@@ -145,7 +166,7 @@ class RatingComponent extends Component {
 	 *
 	 * @param string|int $rate the model record id
 	 * @param float|int $rating
-	 * @param string|int $user
+	 * @param string|int|null $user
 	 * @param array<mixed>|string|bool $redirect boolean to redirect to same url or string or array to use it for Router::url()
 	 * @return \Cake\Http\Response|null
 	 */
@@ -162,7 +183,24 @@ class RatingComponent extends Component {
 			$table = $Controller->getTableLocator()->get($this->getConfig('modelName'));
 			/** @var \Ratings\Model\Behavior\RatableBehavior $behavior */
 			$behavior = $table->getBehavior('Ratable');
-			$newRating = $behavior->saveRating($rate, $user, $rating);
+			try {
+				$newRating = $behavior->saveRating($rate, $user, $rating);
+			} catch (LogicException $e) {
+				$result = ['status' => 'error', 'message' => $e->getMessage(), 'rating' => $rating];
+				$this->Controller->set($result);
+				if ($redirect) {
+					if (is_numeric($redirect)) {
+						$redirect = (bool)$redirect;
+					}
+					if ($redirect === true) {
+						return $this->redirect($this->buildUrl());
+					}
+
+					return $this->redirect($redirect);
+				}
+
+				return null;
+			}
 			if ($newRating) {
 				$rating = round($newRating->rating);
 				$message = __d('ratings', 'Your rate was successful.');

--- a/src/Model/Behavior/RatableBehavior.php
+++ b/src/Model/Behavior/RatableBehavior.php
@@ -39,6 +39,8 @@ class RatableBehavior extends Behavior {
 	 * - modelValidate - validate the model before save, default is false
 	 * - modelCallbacks - run model callbacks when the rating is saved to the model, default is false
 	 * - countRates - counter cache
+	 * - userField - column on the rated model holding its owner user id; when present a user
+	 *   cannot rate their own record (set to null/false to disable the self-vote guard)
 	 *
 	 * @var array<string, mixed>
 	 */
@@ -55,6 +57,7 @@ class RatableBehavior extends Behavior {
 		'update' => false,
 		'modelValidate' => false,
 		'modelCallbacks' => false,
+		'userField' => 'user_id',
 	];
 
 	/**
@@ -123,6 +126,8 @@ class RatableBehavior extends Behavior {
 		if (!$foreignKey) {
 			throw new Exception('Empty $foreignKey is not allowed for saveRating()');
 		}
+
+		$this->assertNotSelfVote($foreignKey, $userId);
 
 		$type = 'saveRating';
 		$update = $this->_config['update'];
@@ -517,8 +522,7 @@ class RatableBehavior extends Behavior {
 		}
 
 		if ($options['userField'] && $this->_table->hasField($options['userField'])) {
-			if ($record[$options['userField']] == $userId) {
-				//$this->_table->data = $record;
+			if ((string)$record[$options['userField']] === (string)$userId) {
 				throw new LogicException(__d('ratings', 'You can not vote on your own records'));
 			}
 		}
@@ -528,6 +532,47 @@ class RatableBehavior extends Behavior {
 		}
 
 		throw new RuntimeException(__d('ratings', 'You have already rated this record'));
+	}
+
+	/**
+	 * Self-vote guard: throws when the rated record's owner equals $userId.
+	 *
+	 * Uses string-cast strict comparison so mixed int/string user ids (UUIDs vs ints,
+	 * leading-zero numeric strings) are compared as identifiers rather than via PHP's
+	 * loose numeric coercion.
+	 *
+	 * Skipped when no userField is configured, the rated model lacks that column,
+	 * the record cannot be loaded, or the userId is empty.
+	 *
+	 * @param string|int $foreignKey
+	 * @param string|int|null $userId
+	 * @throws \LogicException When the user is the owner of the rated record.
+	 * @return void
+	 */
+	protected function assertNotSelfVote($foreignKey, $userId): void {
+		if (!$userId) {
+			return;
+		}
+
+		$userField = $this->_config['userField'] ?? null;
+		if (!$userField || !$this->_table->hasField($userField)) {
+			return;
+		}
+
+		/** @var string $key */
+		$key = $this->_table->getPrimaryKey();
+		$record = $this->_table->find()
+			->select([$userField])
+			->where([$this->_table->getAlias() . '.' . $key => $foreignKey])
+			->first();
+
+		if (!$record) {
+			return;
+		}
+
+		if ((string)$record[$userField] === (string)$userId) {
+			throw new LogicException(__d('ratings', 'You can not vote on your own records'));
+		}
 	}
 
 	/**

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -66,6 +66,16 @@ class ArticlesFixture extends TestFixture {
 			'rating_4' => 0,
 			'rating_5' => 0,
 		],
+		[
+			'user_id' => 5,
+			'title' => 'Owned Article',
+			'rating' => 0.0000,
+			'rating_1' => 0,
+			'rating_2' => 0,
+			'rating_3' => 0,
+			'rating_4' => 0,
+			'rating_5' => 0,
+		],
 	];
 
 }

--- a/tests/TestCase/Model/Behavior/RatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/RatableBehaviorTest.php
@@ -14,6 +14,7 @@ namespace Ratings\Test\TestCase\Model\Behavior;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use InvalidArgumentException;
+use LogicException;
 
 /**
  * CakePHP Ratings Plugin
@@ -424,6 +425,37 @@ class RatableBehaviorTest extends TestCase {
 		$foreignKey = 3;
 		$result = $this->Articles->getBehavior('Ratable')->isRatedBy($foreignKey, $userId)->count();
 		$this->assertSame(0, $result);
+	}
+
+	/**
+	 * The self-vote guard must trigger on the direct saveRating() path -
+	 * not just via the rate() wrapper - since RatingComponent uses saveRating().
+	 *
+	 * @return void
+	 */
+	public function testSaveRatingBlocksSelfVote() {
+		$this->Articles->addBehavior('Ratings.Ratable', []);
+
+		$this->expectException(LogicException::class);
+
+		// Article 3 is owned by user_id 5; same user must not be able to rate it.
+		$this->Articles->getBehavior('Ratable')->saveRating(3, 5, 4);
+	}
+
+	/**
+	 * Equivalent ints/strings ("5" vs 5) must still trip the guard so that a caller
+	 * cannot bypass it by varying the user-id type. Strict (string-cast) comparison
+	 * preserves this while rejecting unrelated ids.
+	 *
+	 * @return void
+	 */
+	public function testSaveRatingSelfVoteStringIntCoercion() {
+		$this->Articles->addBehavior('Ratings.Ratable', []);
+
+		$this->expectException(LogicException::class);
+
+		// String "5" vs stored int 5 - must still be rejected as self-vote.
+		$this->Articles->getBehavior('Ratable')->saveRating(3, '5', 4);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Move the self-vote check from the `rate()` wrapper into `saveRating()` so the `RatingComponent` path (which calls `saveRating()` directly, not `rate()`) also enforces it. The component now catches the resulting `LogicException` and surfaces it as a normal error flash/result instead of crashing.
- Switch the comparison from loose `==` to a string-cast strict `===`, and make the rated-user column configurable via a new `userField` behavior option (defaults to `user_id`, set to falsy to disable the guard).
- Replace the malformed `if / elseif / } if (...) } else { /* commented */ }` ladder in `RatingComponent::startup()` with a small `resolveUserId()` helper. The previous chain left the third branch detached from the second and the trailing `else` unreachable from the first; behavior is now identity → AuthUser → Auth, in that order, with an explicit `null` fallback.

## Tests

- `RatableBehaviorTest::testSaveRatingBlocksSelfVote` covers the new direct-path guard.
- `RatableBehaviorTest::testSaveRatingSelfVoteStringIntCoercion` confirms `'5'` vs stored int `5` is still rejected (no bypass via type juggling).
- All existing tests pass; phpstan level 8 clean; phpcs clean.