### PR TITLE
Shrink phpstan baseline by fixing real type issues

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,8 +8,15 @@ parameters:
 	ignoreErrors:
 		- identifier: missingType.iterableValue
 		- identifier: missingType.generics
-		- identifier: argument.templateType
-		- '#Cannot access property \$rating on float#'
-		- '#Access to an undefined property Cake\\Controller\\Controller::\$AuthUser.#'
-		- '#Access to an undefined property Cake\\Controller\\Controller::\$Auth.#'
-		- '#Access to an undefined property .+\\Table.+::\$Ratings.#'
+		-
+			identifier: argument.templateType
+			path: src/Model/Behavior/RatableBehavior.php
+			count: 3
+		-
+			message: '#Access to an undefined property Cake\\Controller\\Controller::\$AuthUser\.#'
+			path: src/Controller/Component/RatingComponent.php
+			count: 1
+		-
+			message: '#Access to an undefined property Cake\\Controller\\Controller::\$Auth\.#'
+			path: src/Controller/Component/RatingComponent.php
+			count: 1

--- a/src/Controller/Component/RatingComponent.php
+++ b/src/Controller/Component/RatingComponent.php
@@ -12,6 +12,7 @@
 namespace Ratings\Controller\Component;
 
 use Cake\Controller\Component;
+use Cake\Datasource\EntityInterface;
 use Cake\Event\EventInterface;
 use Cake\Http\Response;
 use Cake\ORM\Exception\MissingTableClassException;
@@ -201,8 +202,8 @@ class RatingComponent extends Component {
 
 				return null;
 			}
-			if ($newRating) {
-				$rating = round($newRating->rating);
+			if ($newRating instanceof EntityInterface) {
+				$rating = round((float)$newRating->get('rating'));
 				$message = __d('ratings', 'Your rate was successful.');
 				$status = 'success';
 			} else {

--- a/src/Model/Behavior/RatableBehavior.php
+++ b/src/Model/Behavior/RatableBehavior.php
@@ -245,7 +245,7 @@ class RatableBehavior extends Behavior {
 			'conditions' => [
 				$this->_table->getAlias() . '.' . $key => $id,
 			],
-		])->first();
+		])->firstOrFail();
 
 		$fieldSummary = $this->_config['fieldSummary'];
 		$fieldCounter = $this->_config['fieldCounter'];
@@ -310,7 +310,7 @@ class RatableBehavior extends Behavior {
 			'conditions' => [
 				$this->_table->getAlias() . '.' . $key => $id,
 			],
-		])->first();
+		])->firstOrFail();
 
 		$fieldSummary = $this->_config['fieldSummary'];
 		$fieldCounter = $this->_config['fieldCounter'];
@@ -648,7 +648,7 @@ class RatableBehavior extends Behavior {
 	 */
 	protected function ratingsTable() {
 		/** @var \Ratings\Model\Table\RatingsTable */
-		return $this->_table->Ratings->getTarget();
+		return $this->_table->getAssociation('Ratings')->getTarget();
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Drops two regex-based ignore patterns by fixing the underlying issues at source, and tightens the remaining three to be path/count pinned. Along the way fixes two real bugs the suppressions had been hiding.

## Real fixes

- **RatingComponent::rate()** (line 205): `saveRating()` returns the parent entity (e.g. a Post with a rating field), or float/false. The truthy fallthrough accessed `$newRating->rating` directly — fine on the entity branch where the rated table has a `rating` column, but the static type is `float | EntityInterface | false`, so the `Rating::$rating` access was structurally broken on that branch. Narrow with `instanceof EntityInterface` and read via `get('rating')`.
- **RatableBehavior::incrementRating() / decrementRating()**: both did `find()->first()` followed by `$result[$fieldSummary]` array access — silently null-deref'd when the target row was gone. Switch to `firstOrFail()`. As a side benefit this surfaces cleaner exceptions to callers.
- **RatableBehavior::ratingsTable()**: replace magic `$this->_table->Ratings->getTarget()` with the explicit `getAssociation('Ratings')->getTarget()`.

## Baseline cleanup

`phpstan.neon` ignores: 7 → 5.

- Drop the `Cannot access property $rating on float` regex (fixed at source).
- Drop the `Table::$Ratings undefined property` regex (fixed at source).
- Pin `argument.templateType` to `RatableBehavior.php` with `count: 3` — the Behavior receives a generic `Table<TBehaviors, EntityInterface>` and patchEntity's `TPatchedEntity` can't resolve from there. Path-scoping prevents drift elsewhere from being silently swallowed.
- Pin the legacy `AuthUser` / `Auth` component accessors in RatingComponent each with `path` + `count: 1`. They are a deliberate fallback for apps that haven't migrated to the Authentication plugin's identity attribute, so the suppression stays — but only for the two known lines.

## Verification

`composer cs-check` clean, `composer stan` clean, `composer test` clean (43 tests, 106 assertions).
