### PR TITLE
Rewrite RatingsInit on the migrations API with configurable polymorphic foreign_key

### DIFF
--- a/config/Migrations/20150602143122_RatingsInit.php
+++ b/config/Migrations/20150602143122_RatingsInit.php
@@ -1,5 +1,6 @@
 <?php
 
+use Cake\Core\Configure;
 use Migrations\BaseMigration;
 
 class RatingsInit extends BaseMigration {
@@ -7,47 +8,53 @@ class RatingsInit extends BaseMigration {
 	/**
 	 * Change Method.
 	 *
-	 * More information on this method is available here:
-	 * http://docs.phinx.org/en/latest/migrations.html#the-change-method
-	 *
-	 * Uncomment this method if you would like to use it.
-	 *
-	public function change()
-	{
-	}
-	*/
-
-	/**
-	 * Migrate Up.
-	 *
 	 * @return void
 	 */
-	public function up() {
-		$content = <<<SQL
-CREATE TABLE IF NOT EXISTS `ratings` (
-  `id` int(10) NOT NULL AUTO_INCREMENT,
-  `user_id` int(10) DEFAULT NULL,
-  `foreign_key` int(10) DEFAULT NOT NULL,
-  `model` varchar(255) COLLATE utf8_unicode_ci NOT NULL,
-  `value` float(8,4) NOT NULL DEFAULT '0.0000',
-  `created` datetime NOT NULL,
-  `modified` datetime NOT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `UNIQUE_RATING` (`user_id`,`foreign_key`,`model`),
-  KEY `user_id` (`user_id`),
-  KEY `foreign_key` (`foreign_key`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+	public function change(): void {
+		// foreign_key (the polymorphic host record's primary key, paired with model)
+		// follows the global Polymorphic.type config so apps using UUID primary keys
+		// can store matching foreign keys. user_id is a concrete FK to the app's users
+		// table. For integer types the signedness follows Migrations.unsigned_primary_keys
+		// (signed when unset); only MySQL honors signedness.
+		$type = (string)Configure::read('Polymorphic.type', 'integer');
+		$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
 
-SQL;
-		$this->query($content);
-	}
+		$polymorphicOptions = [
+			'default' => null,
+			'null' => false,
+		];
+		if (in_array($type, ['integer', 'biginteger'], true)) {
+			$polymorphicOptions['signed'] = $signed;
+		}
 
-	/**
-	 * Migrate Down.
-	 *
-	 * @return void
-	 */
-	public function down() {
+		$this->table('ratings')
+			->addColumn('user_id', 'integer', [
+				'default' => null,
+				'null' => true,
+				'signed' => $signed,
+			])
+			->addColumn('foreign_key', $type, $polymorphicOptions)
+			->addColumn('model', 'string', [
+				'default' => null,
+				'limit' => 255,
+				'null' => false,
+			])
+			->addColumn('value', 'float', [
+				'default' => 0,
+				'null' => false,
+				'precision' => 8,
+				'scale' => 4,
+			])
+			->addColumn('created', 'datetime', [
+				'null' => false,
+			])
+			->addColumn('modified', 'datetime', [
+				'null' => false,
+			])
+			->addIndex(['user_id', 'foreign_key', 'model'], ['unique' => true, 'name' => 'UNIQUE_RATING'])
+			->addIndex(['user_id'])
+			->addIndex(['foreign_key'])
+			->create();
 	}
 
 }

--- a/config/app.example.php
+++ b/config/app.example.php
@@ -21,4 +21,13 @@ return [
 		// owner of a rating). When empty, defaults to 'Users'. Default: not set ('Users').
 		'userClass' => 'Users',
 	],
+
+	// Global (cross-plugin) convention read by the RatingsInit migration when creating
+	// the polymorphic `ratings.foreign_key` column. Must be set BEFORE running migrations
+	// on a fresh install. Accepted values: 'integer' (default), 'biginteger', 'uuid',
+	// 'binaryuuid'. For the integer variants the column signedness follows the migrations
+	// plugin's `Migrations.unsigned_primary_keys` flag (signed when unset).
+	'Polymorphic' => [
+		'type' => 'integer',
+	],
 ];


### PR DESCRIPTION
## Problem

`RatingsInit` created the `ratings` table via a raw SQL `CREATE TABLE` string. The polymorphic `foreign_key` was a fixed `int(10)` — it could not follow the app's primary-key type/signedness like the other plugins, and the snippet even contained an invalid `foreign_key int(10) DEFAULT NOT NULL` clause.

## Fix

Rewrite the migration on the migrations `addColumn` API so the schema is configurable and consistent with the other plugins:

- `foreign_key` (the polymorphic host-record reference, paired with `model`) follows the global `Polymorphic.type` config — `integer` (default), `biginteger`, `uuid`, or `binaryuuid`.
- `foreign_key` and `user_id` follow `Migrations.unsigned_primary_keys` signedness for integer variants.
- the primary key uses the auto-increment id following the same flag.

```php
$type = (string)Configure::read('Polymorphic.type', 'integer');
$signed = !(bool)Configure::read('Migrations.unsigned_primary_keys', false);
```

For the default (`integer`) case the resulting schema is equivalent to before. Verified on SQLite for `integer`, `biginteger` and `uuid`. The `Polymorphic.type` key is documented in `config/app.example.php`.

Editing the create migration sets the schema for fresh installs; existing installs are unaffected (the migration does not re-run).
