### PR TITLE
Apply conservative Rector cleanup

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,10 +9,6 @@ parameters:
 		- identifier: missingType.iterableValue
 		- identifier: missingType.generics
 		-
-			identifier: argument.templateType
-			path: src/Model/Behavior/RatableBehavior.php
-			count: 3
-		-
 			message: '#Access to an undefined property Cake\\Controller\\Controller::\$AuthUser\.#'
 			path: src/Controller/Component/RatingComponent.php
 			count: 1

--- a/src/Controller/Component/RatingComponent.php
+++ b/src/Controller/Component/RatingComponent.php
@@ -214,7 +214,7 @@ class RatingComponent extends Component {
 			$message = __d('ratings', 'Invalid rate.');
 			$status = 'error';
 		}
-		$result = compact('status', 'message', 'rating');
+		$result = ['status' => $status, 'message' => $message, 'rating' => $rating];
 		$this->Controller->set($result);
 		if ($redirect) {
 			if (is_numeric($redirect)) {
@@ -268,9 +268,7 @@ class RatingComponent extends Component {
 			$this->Controller->set('message', $this->Controller->viewBuilder()->getVar('authMessage'));
 			$this->Controller->set('status', 'error');
 
-			$response = $this->Controller->getResponse()->withStringBody($this->Controller->render('rate'));
-
-			return $response;
+			return $this->Controller->getResponse()->withStringBody($this->Controller->render('rate'));
 		}
 
 		if ($this->Controller->viewBuilder()->getVar('authMessage')) {

--- a/src/Controller/Component/RatingComponent.php
+++ b/src/Controller/Component/RatingComponent.php
@@ -214,7 +214,7 @@ class RatingComponent extends Component {
 			$message = __d('ratings', 'Invalid rate.');
 			$status = 'error';
 		}
-		$result = ['status' => $status, 'message' => $message, 'rating' => $rating];
+		$result = compact('status', 'message', 'rating');
 		$this->Controller->set($result);
 		if ($redirect) {
 			if (is_numeric($redirect)) {

--- a/src/Model/Behavior/RatableBehavior.php
+++ b/src/Model/Behavior/RatableBehavior.php
@@ -131,7 +131,7 @@ class RatableBehavior extends Behavior {
 
 		$type = 'saveRating';
 		$update = $this->_config['update'];
-		$this->beforeRateCallback(compact('foreignKey', 'userId', 'value', 'update', 'type'));
+		$this->beforeRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'value' => $value, 'update' => $update, 'type' => $type]);
 
 		// Wrap the entire isRatedBy → deleteAll → save → increment chain in a
 		// transaction so two concurrent requests for the same (foreign_key, user_id)
@@ -178,7 +178,7 @@ class RatableBehavior extends Behavior {
 				$result = $this->calculateRating($foreignKey, $this->_config['saveToField'], $this->_config['calculation']);
 			}
 			$update = $wasUpdate;
-			$this->afterRateCallback(compact('foreignKey', 'userId', 'value', 'result', 'update', 'oldRating', 'type'));
+			$this->afterRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'value' => $value, 'result' => $result, 'update' => $update, 'oldRating' => $oldRating, 'type' => $type]);
 
 			return $result;
 		});
@@ -202,7 +202,7 @@ class RatableBehavior extends Behavior {
 
 		$type = 'removeRating';
 		$update = $this->_config['update'];
-		$this->beforeRateCallback(compact('foreignKey', 'userId', 'update', 'type'));
+		$this->beforeRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'update' => $update, 'type' => $type]);
 		/** @var \Ratings\Model\Entity\Rating|null $oldRating */
 		$oldRating = $this->isRatedBy($foreignKey, $userId)->first();
 		if (!$oldRating) {
@@ -224,7 +224,7 @@ class RatableBehavior extends Behavior {
 		} else {
 			$result = $this->calculateRating($foreignKey, $this->_config['saveToField'], $this->_config['calculation']);
 		}
-		$this->afterRateCallback(compact('foreignKey', 'userId', 'result', 'update', 'oldRating', 'type'));
+		$this->afterRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'result' => $result, 'update' => $update, 'oldRating' => $oldRating, 'type' => $type]);
 
 		return $result;
 	}
@@ -263,11 +263,7 @@ class RatableBehavior extends Behavior {
 		$ratingCountNew = $rating[$fieldCounter] - 1;
 
 		if ($mode === 'average') {
-			if ($ratingCountNew === 0) {
-				$ratingSum = 0;
-			} else {
-				$ratingSum = $ratingSumNew / $ratingCountNew;
-			}
+			$ratingSum = $ratingCountNew === 0 ? 0 : $ratingSumNew / $ratingCountNew;
 		} else {
 			$ratingSum = $ratingSumNew;
 		}
@@ -339,11 +335,7 @@ class RatableBehavior extends Behavior {
 			$ratingCountNew = $data[$fieldCounter] + 1;
 		}
 
-		if ($mode === 'average') {
-			$rating = $ratingSumNew / $ratingCountNew;
-		} else {
-			$rating = $ratingSumNew;
-		}
+		$rating = $mode === 'average' ? $ratingSumNew / $ratingCountNew : $ratingSumNew;
 
 		// Store rating for callback access
 		$this->newRating = $rating;
@@ -457,15 +449,13 @@ class RatableBehavior extends Behavior {
 	 * @return \Cake\ORM\Query\SelectQuery
 	 */
 	public function isRatedBy($foreignKey, $userId): SelectQuery {
-		$entry = $this->ratingsTable()->find('all', ...[
+		return $this->ratingsTable()->find('all', ...[
 			'conditions' => [
 				'Ratings.foreign_key' => $foreignKey,
 				'Ratings.user_id' => $userId,
 				'Ratings.model' => $this->_table->getAlias(),
 			],
 		]);
-
-		return $entry;
 	}
 
 	/**
@@ -542,10 +532,8 @@ class RatableBehavior extends Behavior {
 			throw new OutOfBoundsException(__d('ratings', 'Invalid Record'));
 		}
 
-		if ($options['userField'] && $this->_table->hasField($options['userField'])) {
-			if ((string)$record[$options['userField']] === (string)$userId) {
-				throw new LogicException(__d('ratings', 'You can not vote on your own records'));
-			}
+		if ($options['userField'] && $this->_table->hasField($options['userField']) && (string)$record[$options['userField']] === (string)$userId) {
+			throw new LogicException(__d('ratings', 'You can not vote on your own records'));
 		}
 
 		if ($this->saveRating($foreignKey, $userId, $options['values'][$rating])) {

--- a/src/Model/Behavior/RatableBehavior.php
+++ b/src/Model/Behavior/RatableBehavior.php
@@ -131,7 +131,7 @@ class RatableBehavior extends Behavior {
 
 		$type = 'saveRating';
 		$update = $this->_config['update'];
-		$this->beforeRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'value' => $value, 'update' => $update, 'type' => $type]);
+		$this->beforeRateCallback(compact('foreignKey', 'userId', 'value', 'update', 'type'));
 
 		// Wrap the entire isRatedBy → deleteAll → save → increment chain in a
 		// transaction so two concurrent requests for the same (foreign_key, user_id)
@@ -178,7 +178,7 @@ class RatableBehavior extends Behavior {
 				$result = $this->calculateRating($foreignKey, $this->_config['saveToField'], $this->_config['calculation']);
 			}
 			$update = $wasUpdate;
-			$this->afterRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'value' => $value, 'result' => $result, 'update' => $update, 'oldRating' => $oldRating, 'type' => $type]);
+			$this->afterRateCallback(compact('foreignKey', 'userId', 'value', 'result', 'update', 'oldRating', 'type'));
 
 			return $result;
 		});
@@ -202,7 +202,7 @@ class RatableBehavior extends Behavior {
 
 		$type = 'removeRating';
 		$update = $this->_config['update'];
-		$this->beforeRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'update' => $update, 'type' => $type]);
+		$this->beforeRateCallback(compact('foreignKey', 'userId', 'update', 'type'));
 		/** @var \Ratings\Model\Entity\Rating|null $oldRating */
 		$oldRating = $this->isRatedBy($foreignKey, $userId)->first();
 		if (!$oldRating) {
@@ -224,7 +224,7 @@ class RatableBehavior extends Behavior {
 		} else {
 			$result = $this->calculateRating($foreignKey, $this->_config['saveToField'], $this->_config['calculation']);
 		}
-		$this->afterRateCallback(['foreignKey' => $foreignKey, 'userId' => $userId, 'result' => $result, 'update' => $update, 'oldRating' => $oldRating, 'type' => $type]);
+		$this->afterRateCallback(compact('foreignKey', 'userId', 'result', 'update', 'oldRating', 'type'));
 
 		return $result;
 	}

--- a/src/View/Helper/RatingHelper.php
+++ b/src/View/Helper/RatingHelper.php
@@ -134,11 +134,7 @@ class RatingHelper extends Helper {
 
 		$res = '';
 		for ($i = 0; $i < $options['stars']; $i++) {
-			if ((int)$roundedValue > $i) {
-				$k = 'full';
-			} else {
-				$k = 'empty';
-			}
+			$k = (int)$roundedValue > $i ? 'full' : 'empty';
 			// Half-star slot: the integer part of the rating equals $i and the
 			// fractional remainder is at least half a step. The previous
 			// `(2 * $roundedValue + 1) % 2 === 0` was always false for any
@@ -170,13 +166,13 @@ class RatingHelper extends Helper {
 	 * @return string Container with rating images
 	 */
 	protected function _ratingImageJqueryUi($value, array $options = [], array $attributes = []) {
-		$size = !empty($options['size']) ? $options['size'] : '';
+		$size = empty($options['size']) ? '' : $options['size'];
 		if (!empty($size)) {
 			$options['pixels'] = $this->sizes[$size];
 		}
-		$pixels = !empty($options['pixels']) ? $options['pixels'] : 16;
-		$steps = !empty($options['steps']) ? $options['steps'] : 4;
-		$stars = !empty($options['stars']) ? $options['stars'] : 5;
+		$pixels = empty($options['pixels']) ? 16 : $options['pixels'];
+		$steps = empty($options['steps']) ? 4 : $options['steps'];
+		$stars = empty($options['stars']) ? 5 : $options['stars'];
 		if ($value <= 0) {
 			$roundedValue = 0;
 			if (empty($attributes['title'])) {
@@ -200,13 +196,11 @@ class RatingHelper extends Helper {
 				}
 				$v = $array[$disable];
 
-				if ($j === 0) {
-					# try to use a single image if possible
-					if ($i < floor($roundedValue) || $i >= ceil($roundedValue) || $i === 0 && $roundedValue >= 1) {
-						$res .= Text::insert($v, ['margin' => 0, 'width' => $pixels], ['before' => '{', 'after' => '}']);
+				# try to use a single image if possible
+				if ($j === 0 && ($i < floor($roundedValue) || $i >= ceil($roundedValue) || $i === 0 && $roundedValue >= 1)) {
+					$res .= Text::insert($v, ['margin' => 0, 'width' => $pixels], ['before' => '{', 'after' => '}']);
 
-						break;
-					}
+					break;
 				}
 
 				$margin = 0 - ($pixels / $steps) * $j;
@@ -245,18 +239,14 @@ class RatingHelper extends Helper {
 		];
 		$options += $defaults;
 
-		if ($value <= 0) {
-			$roundedValue = 0;
-		} else {
-			$roundedValue = round($value * $options['steps']) / $options['steps'];
-		}
+		$roundedValue = $value <= 0 ? 0 : round($value * $options['steps']) / $options['steps'];
 		$percent = $this->percentage($roundedValue, $options['stars']);
 
 		$title = __d('ratings', '{0} of {1} stars', $this->Number->format(min($roundedValue, $options['stars']), $this->_config), $options['stars']);
 
 		$attrContent = [
 			'class' => 'rating-stars',
-			'data-content' => str_repeat($options['data-symbol'], $options['stars']),
+			'data-content' => str_repeat((string)$options['data-symbol'], $options['stars']),
 			'escape' => $options['escape'],
 			'style' => 'width: ' . $percent . '%',
 		];
@@ -267,7 +257,7 @@ class RatingHelper extends Helper {
 		//</div>
 
 		$attributes += ['title' => $title];
-		$attributes = ['data-content' => str_repeat($options['data-symbol'], $options['stars']), 'escape' => $options['escape']] + $attributes;
+		$attributes = ['data-content' => str_repeat((string)$options['data-symbol'], $options['stars']), 'escape' => $options['escape']] + $attributes;
 
 		return $this->Html->div('rating-container ' . $options['data-rating-class'], $content, $attributes);
 
@@ -392,7 +382,7 @@ class RatingHelper extends Helper {
 		}
 		$inputOptions += $htmlAttributes;
 
-		$result .= '<div id="star_' . $id . '" class="' . (!empty($options['class']) ? $options['class'] : 'rating') . '">';
+		$result .= '<div id="star_' . $id . '" class="' . (empty($options['class']) ? 'rating' : $options['class']) . '">';
 		$result .= $this->Form->control($inputField, $inputOptions);
 		$result .= '</div>';
 		if ($options['createForm']) {
@@ -404,11 +394,7 @@ class RatingHelper extends Helper {
 			$result .= $this->Form->end() . "\n";
 
 			$disabled = empty($options['editable']) ? false : 'disabled';
-			if ($disabled) {
-				$split = 4;
-			} else {
-				$split = 1;
-			}
+			$split = $disabled ? 4 : 1;
 
 			if ($options['js']) {
 				$script = <<<HTML
@@ -434,9 +420,7 @@ HTML;
 			}
 		}
 
-		$result = '<div class="star-rating">' . $result . '</div>';
-
-		return $result;
+		return '<div class="star-rating">' . $result . '</div>';
 	}
 
 	/**

--- a/src/View/Helper/RatingHelper.php
+++ b/src/View/Helper/RatingHelper.php
@@ -166,13 +166,13 @@ class RatingHelper extends Helper {
 	 * @return string Container with rating images
 	 */
 	protected function _ratingImageJqueryUi($value, array $options = [], array $attributes = []) {
-		$size = empty($options['size']) ? '' : $options['size'];
+		$size = !empty($options['size']) ? $options['size'] : '';
 		if (!empty($size)) {
 			$options['pixels'] = $this->sizes[$size];
 		}
-		$pixels = empty($options['pixels']) ? 16 : $options['pixels'];
-		$steps = empty($options['steps']) ? 4 : $options['steps'];
-		$stars = empty($options['stars']) ? 5 : $options['stars'];
+		$pixels = !empty($options['pixels']) ? $options['pixels'] : 16;
+		$steps = !empty($options['steps']) ? $options['steps'] : 4;
+		$stars = !empty($options['stars']) ? $options['stars'] : 5;
 		if ($value <= 0) {
 			$roundedValue = 0;
 			if (empty($attributes['title'])) {
@@ -382,7 +382,7 @@ class RatingHelper extends Helper {
 		}
 		$inputOptions += $htmlAttributes;
 
-		$result .= '<div id="star_' . $id . '" class="' . (empty($options['class']) ? 'rating' : $options['class']) . '">';
+		$result .= '<div id="star_' . $id . '" class="' . (!empty($options['class']) ? $options['class'] : 'rating') . '">';
 		$result .= $this->Form->control($inputField, $inputOptions);
 		$result .= '</div>';
 		if ($options['createForm']) {

--- a/tests/Fixture/UsersFixture.php
+++ b/tests/Fixture/UsersFixture.php
@@ -146,7 +146,7 @@ class UsersFixture extends TestFixture {
 	public function __construct() {
 		parent::__construct();
 		foreach ($this->records as &$record) {
-			$record['passwd'] = sha1($record['passwd']); //, null, true
+			$record['passwd'] = sha1((string)$record['passwd']); //, null, true
 		}
 	}
 

--- a/tests/TestCase/Controller/Component/RatingComponentTest.php
+++ b/tests/TestCase/Controller/Component/RatingComponentTest.php
@@ -129,7 +129,7 @@ class RatingComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testStartup() {
-		$this->Controller->getRequest()->getSession()->write('Flash', null);
+		$this->Controller->getRequest()->getSession()->write('Flash');
 
 		$params = [
 			'plugin' => null,
@@ -152,7 +152,7 @@ class RatingComponentTest extends TestCase {
 		$this->Controller->getRequest()->getSession()->expectAt(1, 'setFlash', array('You have already rated.', 'default', array(), 'error'));
 		$this->Controller->getRequest()->getSession()->expectAt(2, 'setFlash', array('Invalid rate.', 'default', array(), 'error'));
 		*/
-		$this->Controller->getRequest()->getSession()->write('Flash', null);
+		$this->Controller->getRequest()->getSession()->write('Flash');
 		ServerRequest::addDetector('post', function() {
 			return true;
 		});
@@ -171,7 +171,7 @@ class RatingComponentTest extends TestCase {
 		];
 		$this->assertSame($expectedFlash, $sessionFlash);
 
-		$this->Controller->getRequest()->getSession()->write('Flash', null);
+		$this->Controller->getRequest()->getSession()->write('Flash');
 		$options = [
 			'userId' => 1,
 		];

--- a/tests/TestCase/Controller/Component/RatingComponentTest.php
+++ b/tests/TestCase/Controller/Component/RatingComponentTest.php
@@ -129,7 +129,7 @@ class RatingComponentTest extends TestCase {
 	 * @return void
 	 */
 	public function testStartup() {
-		$this->Controller->getRequest()->getSession()->write('Flash');
+		$this->Controller->getRequest()->getSession()->delete('Flash');
 
 		$params = [
 			'plugin' => null,
@@ -152,7 +152,7 @@ class RatingComponentTest extends TestCase {
 		$this->Controller->getRequest()->getSession()->expectAt(1, 'setFlash', array('You have already rated.', 'default', array(), 'error'));
 		$this->Controller->getRequest()->getSession()->expectAt(2, 'setFlash', array('Invalid rate.', 'default', array(), 'error'));
 		*/
-		$this->Controller->getRequest()->getSession()->write('Flash');
+		$this->Controller->getRequest()->getSession()->delete('Flash');
 		ServerRequest::addDetector('post', function() {
 			return true;
 		});
@@ -171,7 +171,7 @@ class RatingComponentTest extends TestCase {
 		];
 		$this->assertSame($expectedFlash, $sessionFlash);
 
-		$this->Controller->getRequest()->getSession()->write('Flash');
+		$this->Controller->getRequest()->getSession()->delete('Flash');
 		$options = [
 			'userId' => 1,
 		];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,7 +16,7 @@ if (!defined('DS')) {
 	define('DS', DIRECTORY_SEPARATOR);
 }
 if (!defined('WINDOWS')) {
-	if (DS === '\\' || substr(PHP_OS, 0, 3) === 'WIN') {
+	if (DS === '\\' || str_starts_with(PHP_OS, 'WIN')) {
 		define('WINDOWS', true);
 	} else {
 		define('WINDOWS', false);

--- a/tests/schema.php
+++ b/tests/schema.php
@@ -21,7 +21,7 @@ foreach ($iterator as $file) {
 		$tableObject = (new ReflectionClass($class))->getProperty('table');
 		$tableName = $tableObject->getDefaultValue();
 
-	} catch (ReflectionException $e) {
+	} catch (ReflectionException) {
 		continue;
 	}
 


### PR DESCRIPTION
Applies the same conservative, behavior-neutral Rector cleanup pass as used in dereuromark/cakephp-ide-helper#452, but without committing Rector config or dependency wiring here.

- dead-code and code-quality simplifications only
- excludes the same unsafe / opinionated ruleset areas
- keeps the PR scope to generated cleanup changes in `src/` and `tests/`

This was generated with a temporary local Rector config and followed with CS fixes where needed.