### PR TITLE
Document polymorphic rating key types

### DIFF
--- a/src/Model/Entity/Rating.php
+++ b/src/Model/Entity/Rating.php
@@ -8,7 +8,7 @@ use Cake\ORM\Entity;
  * Album Entity
  *
  * @property int $id
- * @property int|string $user_id
+ * @property int $user_id
  * @property string $model
  * @property int|string $foreign_key
  * @property float $value

--- a/src/Model/Entity/Rating.php
+++ b/src/Model/Entity/Rating.php
@@ -8,9 +8,9 @@ use Cake\ORM\Entity;
  * Album Entity
  *
  * @property int $id
- * @property int $user_id
+ * @property int|string $user_id
  * @property string $model
- * @property int $foreign_key
+ * @property int|string $foreign_key
  * @property float $value
  * @property \Cake\I18n\Time $created
  * @property \Cake\I18n\Time $modified


### PR DESCRIPTION
## Summary
- document the polymorphic `foreign_key` as `int|string`
- keep the non-polymorphic user-id docs integer-based

## Testing
- php -l src/Model/Entity/Rating.php